### PR TITLE
feat(extra): collectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
 		{
 			"name": "socram03",
 			"url": "https://github.com/socram03"
+		},
+		{
+			"name": "Drylozu",
+			"url": "https://github.com/Drylozu"
 		}
 	],
 	"homepage": "https://biscuitjs.com",

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -44,6 +44,10 @@
 		{
 			"name": "socram03",
 			"url": "https://github.com/socram03"
+		},
+		{
+			"name": "Drylozu",
+			"url": "https://github.com/Drylozu"
 		}
 	],
 	"homepage": "https://biscuitjs.com",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -48,6 +48,10 @@
 		{
 			"name": "socram03",
 			"url": "https://github.com/socram03"
+		},
+		{
+			"name": "Drylozu",
+			"url": "https://github.com/Drylozu"
 		}
 	],
 	"homepage": "https://biscuitjs.com",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,10 @@
 		{
 			"name": "socram03",
 			"url": "https://github.com/socram03"
+		},
+		{
+			"name": "Drylozu",
+			"url": "https://github.com/Drylozu"
 		}
 	],
 	"homepage": "https://biscuitjs.com",

--- a/packages/extra/package.json
+++ b/packages/extra/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@biscuitland/rest",
+	"name": "@biscuitland/extra",
 	"version": "1.1.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -22,8 +22,8 @@
 			"require": "./dist/index.js"
 		}
 	},
-	"dependencies": {
-		"@biscuitland/api-types": "^1.1.0"
+	"peerDependencies": {
+		"@biscuitland/core": "^1.1.0"
 	},
 	"devDependencies": {
 		"tsup": "^6.1.3"

--- a/packages/extra/src/collectors.ts
+++ b/packages/extra/src/collectors.ts
@@ -66,6 +66,6 @@ export class Collector<E extends keyof Events> extends EventEmitter {
     once(event: 'collect', listener: (...args: Parameters<Events[E]>) => unknown): this;
     once(event: 'end', listener: (reason: string | null | undefined, collected: Set<Parameters<Events[E]>[0]>) => void): this;
     once(event: string, listener: unknown): this {
-        return super.on(event, listener as (() => unknown));
+        return super.once(event, listener as (() => unknown));
     }
 }

--- a/packages/extra/src/collectors.ts
+++ b/packages/extra/src/collectors.ts
@@ -1,0 +1,71 @@
+import { Session, Events } from '@biscuitland/core';
+import { EventEmitter } from 'node:events';
+
+interface CollectorOptions<E extends keyof Events> {
+    event: E;
+    filter?(...args: Parameters<Events[E]>): unknown;
+    max?: number;
+    time?: number;
+    idle?: number;
+}
+
+export class Collector<E extends keyof Events> extends EventEmitter {
+    collected = new Set<Parameters<Events[E]>[0]>();
+    ended = false;
+    private timeout: NodeJS.Timeout;
+
+    constructor(readonly session: Session, public options: CollectorOptions<E>) {
+        super();
+
+        if (!('filter' in this.options))
+            this.options.filter = (() => true);
+
+        if (!('max' in this.options))
+            this.options.max = -1;
+
+        this.session.events.setMaxListeners(this.session.events.getMaxListeners() + 1);
+
+        this.session.events.on(this.options.event, (...args: unknown[]) => this.collect(...args as Parameters<Events[E]>));
+
+        this.timeout = setTimeout(() => this.stop('time'), this.options.idle ?? this.options.time);
+    }
+
+    private collect(...args: Parameters<Events[E]>) {
+        if (this.options.filter?.(...args)) {
+            this.collected.add(args[0]);
+            this.emit('collect', ...args);
+        }
+
+        if (this.options.idle) {
+            clearTimeout(this.timeout);
+            this.timeout = setTimeout(() => this.stop('time'), this.options.idle);
+        }
+
+        if (this.collected.size >= this.options.max!)
+            this.stop('max');
+    }
+
+    stop(reason?: string) {
+        if (this.ended) return;
+
+        clearTimeout(this.timeout);
+
+        this.session.events.removeListener(this.options.event, (...args: unknown[]) => this.collect(...args as Parameters<Events[E]>));
+        this.session.events.setMaxListeners(this.session.events.getMaxListeners() - 1);
+
+        this.ended = true;
+        this.emit('end', reason, this.collected);
+    }
+
+    on(event: 'collect', listener: (...args: Parameters<Events[E]>) => unknown): this;
+    on(event: 'end', listener: (reason: string | null | undefined, collected: Set<Parameters<Events[E]>[0]>) => void): this;
+    on(event: string, listener: unknown): this {
+        return super.on(event, listener as (() => unknown));
+    }
+
+    once(event: 'collect', listener: (...args: Parameters<Events[E]>) => unknown): this;
+    once(event: 'end', listener: (reason: string | null | undefined, collected: Set<Parameters<Events[E]>[0]>) => void): this;
+    once(event: string, listener: unknown): this {
+        return super.on(event, listener as (() => unknown));
+    }
+}

--- a/packages/extra/src/collectors.ts
+++ b/packages/extra/src/collectors.ts
@@ -1,4 +1,4 @@
-import { Session, Events } from '@biscuitland/core';
+import type { Session, Events } from '@biscuitland/core';
 import { EventEmitter } from 'node:events';
 
 interface CollectorOptions<E extends keyof Events> {

--- a/packages/extra/src/index.ts
+++ b/packages/extra/src/index.ts
@@ -1,0 +1,1 @@
+export * from './collectors';

--- a/packages/extra/tsconfig.json
+++ b/packages/extra/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/extra/tsup.config.ts
+++ b/packages/extra/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export default defineConfig({
+	clean: true,
+	dts: true,
+	entry: ['src/index.ts'],
+	format: ['cjs', 'esm'],
+	minify: isProduction,
+	sourcemap: true,
+});

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -50,6 +50,10 @@
 		{
 			"name": "socram03",
 			"url": "https://github.com/socram03"
+		},
+		{
+			"name": "Drylozu",
+			"url": "https://github.com/Drylozu"
 		}
 	],
 	"homepage": "https://biscuitjs.com",

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,9 @@
 	"$schema": "https://turborepo.org/schema.json",
 	"baseBranch": "origin/main",
 	"pipeline": {
+		"@biscuitland/extra#build": {
+			"dependsOn": []
+		},
 		"@biscuitland/api-types#build": {
 			"dependsOn": []
 		},

--- a/turbo.json
+++ b/turbo.json
@@ -2,9 +2,6 @@
 	"$schema": "https://turborepo.org/schema.json",
 	"baseBranch": "origin/main",
 	"pipeline": {
-		"@biscuitland/extra#build": {
-			"dependsOn": []
-		},
 		"@biscuitland/api-types#build": {
 			"dependsOn": []
 		},
@@ -19,6 +16,9 @@
 		},
 		"@biscuitland/core#build": {
 			"dependsOn": ["@biscuitland/api-types#build", "@biscuitland/rest#build", "@biscuitland/ws#build"]
+		},
+		"@biscuitland/extra#build": {
+			"dependsOn": ["@biscuitland/core#build"]
 		},
 		"clean": {
 			"cache": false


### PR DESCRIPTION
Hey! You're doing a great job with the lib and I wanted to contribute so I made an 'extra' package which currently only has collectors and they can be used in any event.

Cool example
```ts
import { GatewayIntents } from '@biscuitland/api-types';
import { Session, Events } from '@biscuitland/core';
import { Collector } from '@biscuitland/extra';

const session = new Session({
    token: 'token',
    intents: GatewayIntents.MessageContent | GatewayIntents.GuildMessages | GatewayIntents.GuildMembers
});

session.events.on('messageCreate', async (message) => {
    if (message.content === '!nick') {
        let nick = message.member?.nickname ?? message.author.username;

        const m = await message.reply({
            content: `your nickname is ${nick}`
        });

        const collector = new Collector(session, {
            event: 'guildMemberUpdate',
            filter: (member) => member.id === message.author.id && (member.nickname ?? member.user.username) !== nick,
            time: 20e3
        });

        collector.on('collect', (member) => {
            nick = member.nickname ?? member.user.username;
            m.edit({ content: `your nickname is ${nick}` }).catch(console.error);
        });
    }
});

session.start();
```