### PR TITLE
fix: avatarURL doesn't correctly return the default avatar

### DIFF
--- a/packages/core/src/structures/members.ts
+++ b/packages/core/src/structures/members.ts
@@ -39,8 +39,8 @@ export class Member implements Model {
 			? Number.parseInt(data.premium_since)
 			: undefined;
 
-        this.channelPermissions = data.permissions ? new Permissions(BigInt(data.permissions)) : undefined;
-        this.joinedTimestamp = Number.parseInt(data.joined_at);
+		this.channelPermissions = data.permissions ? new Permissions(BigInt(data.permissions)) : undefined;
+		this.joinedTimestamp = Number.parseInt(data.joined_at);
 		this.roles = data.roles;
 		this.deaf = !!data.deaf;
 		this.mute = !!data.mute;
@@ -69,8 +69,8 @@ export class Member implements Model {
 	/** when the user started boosting the guild */
 	premiumSince?: number;
 
-    /** total permissions of the member in the channel, including overwrites, returned when in the interaction object */
-    channelPermissions?: Permissions;
+	/** total permissions of the member in the channel, including overwrites, returned when in the interaction object */
+	channelPermissions?: Permissions;
 
 	/** when the user joined the guild */
 	joinedTimestamp: number;
@@ -146,10 +146,10 @@ export class Member implements Model {
 		return member;
 	}
 
-    /** calls {@link Member#edit} which calls {@link Guild#editMember} under the hood */
-    async timeout(time: number | null) {
-        await this.edit({ communicationDisabledUntil: time });
-    }
+	/** calls {@link Member#edit} which calls {@link Guild#editMember} under the hood */
+	async timeout(time: number | null) {
+		await this.edit({ communicationDisabledUntil: time });
+	}
 
 	/** adds a role to this member */
 	async addRole(roleId: Snowflake, reason?: string): Promise<void> {
@@ -174,30 +174,22 @@ export class Member implements Model {
 		);
 	}
 
-    async fetch(): Promise<Member> {
-        const member = await Guild.prototype.fetchMember.call({ session: this.session, id: this.guildId }, this.id);
+	async fetch(): Promise<Member> {
+		const member = await Guild.prototype.fetchMember.call({ session: this.session, id: this.guildId }, this.id);
 
-        return member;
-    }
+		return member;
+	}
 
 	/** gets the members's guild avatar, not to be confused with Member.user.avatarURL() */
 	avatarURL(options: AvatarOptions): string {
-		let url: string;
-
-		if (this.user.bot) {
-			return this.user.avatarURL(options);
-		}
-
 		if (!this.avatarHash) {
-			url = USER_DEFAULT_AVATAR(Number(this.user.discriminator) % 5);
-		} else {
-			url = USER_AVATAR(
-				this.user.id,
-				this.avatarHash
-			);
+			return USER_DEFAULT_AVATAR(Number(this.user.discriminator) % 5);
 		}
 
-		return Util.formatImageURL(url, options.size ?? 128, options.format);
+		return Util.formatImageURL(USER_AVATAR(
+			this.user.id,
+			this.avatarHash
+		), options.size ?? 128, options.format);
 	}
 
 	/**

--- a/packages/core/src/structures/members.ts
+++ b/packages/core/src/structures/members.ts
@@ -10,11 +10,7 @@ import type { AvatarOptions } from './user';
 import { User } from './user';
 import { Guild } from './guilds';
 import { Util } from '../utils/util';
-import {
-	USER_AVATAR,
-	USER_DEFAULT_AVATAR,
-	THREAD_USER,
-} from '@biscuitland/api-types';
+import { USER_AVATAR, THREAD_USER } from '@biscuitland/api-types';
 import { Permissions } from './special/permissions';
 
 /**
@@ -180,10 +176,10 @@ export class Member implements Model {
 		return member;
 	}
 
-	/** gets the members's guild avatar, not to be confused with Member.user.avatarURL() */
+	/** gets the members's guild avatar if the user has one, gets the user's avatar instead */
 	avatarURL(options: AvatarOptions): string {
 		if (!this.avatarHash) {
-			return USER_DEFAULT_AVATAR(Number(this.user.discriminator) % 5);
+			return this.user.avatarURL(options);
 		}
 
 		return Util.formatImageURL(USER_AVATAR(

--- a/packages/core/src/structures/special/permissions.ts
+++ b/packages/core/src/structures/special/permissions.ts
@@ -121,7 +121,7 @@ export class Permissions implements BitField<bigint> {
 		}
 	}
 
-    static sum(permissions: Array<bigint | number>) {
+    static sum(permissions: (bigint | number)[]) {
         return permissions.reduce((y, x) => BigInt(y) | BigInt(x), Permissions.None);
     }
 

--- a/packages/core/src/structures/user.ts
+++ b/packages/core/src/structures/user.ts
@@ -27,7 +27,7 @@ export class User implements Model {
 			? data.avatar
 			: undefined;
 
-        this.accentColor = data.accent_color;
+		this.accentColor = data.accent_color;
 		this.bot = !!data.bot;
 		this.system = !!data.system;
 		this.banner = data.banner
@@ -103,15 +103,14 @@ export class User implements Model {
 
 	/** gets the user's avatar */
 	avatarURL(options: AvatarOptions): string {
-		let url: string;
-
 		if (!this.avatarHash) {
-			url = USER_DEFAULT_AVATAR(Number(this.discriminator) % 5);
-		} else {
-			url = USER_AVATAR(this.id, this.avatarHash);
+			return USER_DEFAULT_AVATAR(Number(this.discriminator) % 5);
 		}
 
-		return Util.formatImageURL(url, options.size ?? 128, options.format);
+		return Util.formatImageURL(USER_AVATAR(
+			this.id,
+			this.avatarHash
+		), options.size ?? 128, options.format);
 	}
 
 	openDM(): Promise<DMChannel> {


### PR DESCRIPTION
`USER_DEFAULT_AVATAR` of `api-types` returns the default avatar with `.png` as extension (as it should be) but `avatarURL` adds the format and size specified in `options` parameter.

The `USER_DEFAULT_AVATAR` endpoint has no formats other than `.png` and the size doesn't matter, it will always be 256x256.

The `Member#avatarURL` shouldn't return the default avatar if they don't have one within the guild. It should look for the user's avatar or return `undefined`/`null` instead. I made it return the user's avatar but if this is not how you expect it to work, you can change it.

Thanks :)!