### PR TITLE
fix(routes): remove trailing slash from USER_GUILDS

### DIFF
--- a/packages/api-types/src/utils/routes.ts
+++ b/packages/api-types/src/utils/routes.ts
@@ -121,7 +121,7 @@ export function GUILD_ROLES(guildId: Snowflake): string {
 
 export function USER_GUILDS(guildId?: Snowflake): string {
 	if (guildId) { return `/users/@me/guilds/${guildId}`; }
-	return `/users/@me/guilds/`;
+	return `/users/@me/guilds`;
 }
 
 export function USER_DM() {


### PR DESCRIPTION
Discord returns 404 when trying to GET /users/@me/guilds/